### PR TITLE
Fix logic in service for updating joint limits

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/cartesian_trajectory_generator.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/cartesian_trajectory_generator.hpp
@@ -72,6 +72,10 @@ protected:
 private:
   void reference_callback(const std::shared_ptr<ControllerReferenceMsg> msg);
 
+  void set_joint_limits_service_callback(
+    const std::shared_ptr<SetLimitsModeSrvType::Request> request,
+    std::shared_ptr<SetLimitsModeSrvType::Response> response);
+
   std::vector<joint_limits::JointLimits> configured_joint_limits_;
 };
 

--- a/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
+++ b/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
@@ -142,83 +142,12 @@ controller_interface::CallbackReturn CartesianTrajectoryGenerator::on_configure(
   services_qos.reliable();
   services_qos.durability_volatile();
 
-  // Control mode service
-  auto set_joint_limits_service_callback =
-    [&](
-      const std::shared_ptr<SetLimitsModeSrvType::Request> request,
-      std::shared_ptr<SetLimitsModeSrvType::Response> response) {
-      response->ok = true;
-      if (request->names.size() != request->limits.size())
-      {
-        RCLCPP_WARN(
-          get_node()->get_logger(),
-          "Fields name and limits have size %zu and %zu. Their size should be equal. Ignoring "
-          "service call!",
-          request->names.size(), request->limits.size());
-        response->ok = false;
-      }
-
-      auto new_joint_limits = configured_joint_limits_;
-
-      for (size_t i = 0; i < request->names.size(); ++i)
-      {
-        auto it =
-          std::find(command_joint_names_.begin(), command_joint_names_.end(), request->names[i]);
-        if (it != command_joint_names_.end())
-        {
-          auto cmd_itf_index = std::distance(command_joint_names_.begin(), it);
-
-          if (!std::isnan(request->limits[i].min_position))
-          {
-            new_joint_limits[cmd_itf_index].min_position = request->limits[i].min_position;
-            new_joint_limits[cmd_itf_index].has_position_limits = true;
-          }
-          if (!std::isnan(request->limits[i].max_position))
-          {
-            new_joint_limits[cmd_itf_index].max_position = request->limits[i].max_position;
-            new_joint_limits[cmd_itf_index].has_position_limits = true;
-          }
-          if (!std::isnan(request->limits[i].max_velocity))
-          {
-            new_joint_limits[cmd_itf_index].max_velocity = request->limits[i].max_velocity;
-            new_joint_limits[cmd_itf_index].has_velocity_limits = true;
-          }
-          if (!std::isnan(request->limits[i].max_acceleration))
-          {
-            new_joint_limits[cmd_itf_index].max_acceleration = request->limits[i].max_acceleration;
-            new_joint_limits[cmd_itf_index].has_acceleration_limits = true;
-          }
-          if (!std::isnan(request->limits[i].max_jerk))
-          {
-            new_joint_limits[cmd_itf_index].max_jerk = request->limits[i].max_jerk;
-            new_joint_limits[cmd_itf_index].has_jerk_limits = true;
-          }
-          if (!std::isnan(request->limits[i].max_effort))
-          {
-            new_joint_limits[cmd_itf_index].max_effort = request->limits[i].max_effort;
-            new_joint_limits[cmd_itf_index].has_effort_limits = true;
-          }
-
-          RCLCPP_INFO(
-            get_node()->get_logger(), "New limits for joint %zu (%s) are: \n%s", cmd_itf_index,
-            command_joint_names_[cmd_itf_index].c_str(),
-            new_joint_limits[cmd_itf_index].to_string().c_str());
-
-          // TODO(destogl): use buffers to sync comm between threads
-          joint_limits_ = new_joint_limits;
-        }
-        else
-        {
-          RCLCPP_WARN(
-            get_node()->get_logger(), "Name '%s' is not command interface. Ignoring this entry.",
-            request->names[i].c_str());
-          response->ok = false;
-        }
-      }
-    };
-
   set_joint_limits_service_ = get_node()->create_service<SetLimitsModeSrvType>(
-    "~/set_joint_limits", set_joint_limits_service_callback, services_qos);
+    "~/set_joint_limits",
+    std::bind(
+      &CartesianTrajectoryGenerator::set_joint_limits_service_callback, this, std::placeholders::_1,
+      std::placeholders::_2),
+    services_qos);
 
   return CallbackReturn::SUCCESS;
 }
@@ -271,6 +200,125 @@ void CartesianTrajectoryGenerator::reference_callback(
     msg->transforms[0].rotation.z, msg->velocities[0].angular.z, joint_names_[5], 5);
 
   add_new_trajectory_msg(new_traj_msg);
+}
+
+void CartesianTrajectoryGenerator::set_joint_limits_service_callback(
+  const std::shared_ptr<SetLimitsModeSrvType::Request> request,
+  std::shared_ptr<SetLimitsModeSrvType::Response> response)
+{
+  response->ok = true;
+  if (request->names.size() != request->limits.size())
+  {
+    RCLCPP_WARN(
+      get_node()->get_logger(),
+      "Fields name and limits have size %zu and %zu. Their size should be equal. Ignoring "
+      "service call!",
+      request->names.size(), request->limits.size());
+    response->ok = false;
+  }
+
+  // start with current limits
+  auto new_joint_limits = joint_limits_;
+
+  // lambda for setting new limit
+  auto update_limit_from_request = [](
+                                     double & new_limit_value, bool & new_limit_has_limits,
+                                     const double request_limit_value,
+                                     const double configured_limit_value)
+  {
+    // request is to reset to configured limit
+    if (std::isnan(request_limit_value))
+    {
+      new_limit_value = configured_limit_value;
+      new_limit_has_limits = !std::isnan(configured_limit_value);
+    }
+    // new limit is requested
+    else
+    {
+      new_limit_value = request_limit_value;
+      new_limit_has_limits = true;
+    }
+  };
+
+  // lambda for setting new position limits
+  auto update_pos_limits_from_request =
+    [](
+      double & new_min_limit_value, double & new_max_limit_value, bool & new_limit_has_limits,
+      const double request_min_limit_value, const double request_max_limit_value,
+      const double configured_min_limit_value, const double configured_max_limit_value)
+  {
+    // request is to reset to configured min position limit
+    if (std::isnan(request_min_limit_value))
+    {
+      new_min_limit_value = configured_min_limit_value;
+    }
+    // new min position limit is requested
+    else
+    {
+      new_min_limit_value = request_min_limit_value;
+    }
+
+    // request is to reset to configured max position limit
+    if (std::isnan(request_max_limit_value))
+    {
+      new_max_limit_value = configured_max_limit_value;
+    }
+    // new max position limit is requested
+    else
+    {
+      new_max_limit_value = request_max_limit_value;
+    }
+
+    // has limits only if one of the min or max position limits is set
+    new_limit_has_limits = !std::isnan(new_min_limit_value) || !std::isnan(new_max_limit_value);
+  };
+
+  for (size_t i = 0; i < request->names.size(); ++i)
+  {
+    auto it =
+      std::find(command_joint_names_.begin(), command_joint_names_.end(), request->names[i]);
+    if (it != command_joint_names_.end())
+    {
+      auto cmd_itf_index = std::distance(command_joint_names_.begin(), it);
+
+      update_pos_limits_from_request(
+        new_joint_limits[cmd_itf_index].min_position, new_joint_limits[cmd_itf_index].max_position,
+        new_joint_limits[cmd_itf_index].has_position_limits, request->limits[i].min_position,
+        request->limits[i].max_position, configured_joint_limits_[cmd_itf_index].min_position,
+        configured_joint_limits_[cmd_itf_index].max_position);
+      update_limit_from_request(
+        new_joint_limits[cmd_itf_index].max_velocity,
+        new_joint_limits[cmd_itf_index].has_velocity_limits, request->limits[i].max_velocity,
+        configured_joint_limits_[cmd_itf_index].max_velocity);
+      update_limit_from_request(
+        new_joint_limits[cmd_itf_index].max_acceleration,
+        new_joint_limits[cmd_itf_index].has_acceleration_limits,
+        request->limits[i].max_acceleration,
+        configured_joint_limits_[cmd_itf_index].max_acceleration);
+      update_limit_from_request(
+        new_joint_limits[cmd_itf_index].max_jerk, new_joint_limits[cmd_itf_index].has_jerk_limits,
+        request->limits[i].max_jerk, configured_joint_limits_[cmd_itf_index].max_jerk);
+      update_limit_from_request(
+        new_joint_limits[cmd_itf_index].max_effort,
+        new_joint_limits[cmd_itf_index].has_effort_limits, request->limits[i].max_effort,
+        configured_joint_limits_[cmd_itf_index].max_effort);
+
+      RCLCPP_INFO(
+        get_node()->get_logger(), "New limits for joint %zu (%s) are: \n%s", cmd_itf_index,
+        command_joint_names_[cmd_itf_index].c_str(),
+        new_joint_limits[cmd_itf_index].to_string().c_str());
+    }
+    else
+    {
+      RCLCPP_WARN(
+        get_node()->get_logger(), "Name '%s' is not command interface. Ignoring this entry.",
+        request->names[i].c_str());
+      response->ok = false;
+    }
+  }
+
+  // TODO(destogl): use buffers to sync comm between threads
+  joint_limits_ = new_joint_limits;
 }
 
 controller_interface::CallbackReturn CartesianTrajectoryGenerator::on_activate(
@@ -374,7 +422,6 @@ void CartesianTrajectoryGenerator::read_state_from_hardware(JointTrajectoryPoint
 
   state.accelerations.clear();
 }
-
 }  // namespace cartesian_trajectory_generator
 
 #include "pluginlib/class_list_macros.hpp"

--- a/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
+++ b/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
@@ -230,14 +230,13 @@ void CartesianTrajectoryGenerator::set_joint_limits_service_callback(
     if (std::isnan(request_limit_value))
     {
       new_limit_value = configured_limit_value;
-      new_limit_has_limits = !std::isnan(configured_limit_value);
     }
     // new limit is requested
     else
     {
       new_limit_value = request_limit_value;
-      new_limit_has_limits = true;
     }
+    new_limit_has_limits = !std::isnan(new_limit_value);
   };
 
   // lambda for setting new position limits

--- a/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
+++ b/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
@@ -182,7 +182,8 @@ void CartesianTrajectoryGenerator::reference_callback(
     new_traj_msg->points[0].velocities[index] = vel_from_msg;
     if (std::isnan(pos_from_msg) && std::isnan(vel_from_msg))
     {
-      RCLCPP_DEBUG(get_node()->get_logger(), "Input position and velocity is NaN");
+      RCLCPP_DEBUG(
+        get_node()->get_logger(), "Input position and velocity for %s is NaN", joint_name.c_str());
     }
   };
 


### PR DESCRIPTION
The previous logic for updating joint limits had the following issues: 
- if you changed limit for only one joint in the service request, all the other joints were modified to the configured limits - this is not what you want. You only want to go back to configured limit if the value in the service request was set to nan. Otherwise you want to preserve the current limit.
- The limits were being updated for every limit in the service request instead of once at the end

This PR fixes the above issues.