### PR TITLE
Add a reliable reference topic as well

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/cartesian_trajectory_generator.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/cartesian_trajectory_generator.hpp
@@ -62,6 +62,7 @@ protected:
 
   // Command subscribers and Controller State publisher
   rclcpp::Subscription<ControllerReferenceMsg>::SharedPtr ref_subscriber_ = nullptr;
+  rclcpp::Subscription<ControllerReferenceMsg>::SharedPtr ref_subscriber_reliable_ = nullptr;
   realtime_tools::RealtimeBuffer<std::shared_ptr<ControllerReferenceMsg>> input_ref_;
 
   rclcpp::Subscription<ControllerFeedbackMsg>::SharedPtr feedback_subscriber_ = nullptr;

--- a/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
+++ b/joint_trajectory_controller/src/cartesian_trajectory_generator.cpp
@@ -116,10 +116,16 @@ controller_interface::CallbackReturn CartesianTrajectoryGenerator::on_configure(
   auto subscribers_qos = rclcpp::SystemDefaultsQoS();
   subscribers_qos.keep_last(1);
   subscribers_qos.best_effort();
+  auto subscribers_reliable_qos = rclcpp::SystemDefaultsQoS();
+  subscribers_reliable_qos.keep_all();
+  subscribers_reliable_qos.reliable();
 
-  // Reference Subscriber
+  // Reference Subscribers (reliable channel also for updates not to be missed)
   ref_subscriber_ = get_node()->create_subscription<ControllerReferenceMsg>(
     "~/reference", subscribers_qos,
+    std::bind(&CartesianTrajectoryGenerator::reference_callback, this, std::placeholders::_1));
+  ref_subscriber_reliable_ = get_node()->create_subscription<ControllerReferenceMsg>(
+    "~/reference_reliable", subscribers_qos,
     std::bind(&CartesianTrajectoryGenerator::reference_callback, this, std::placeholders::_1));
 
   std::shared_ptr<ControllerReferenceMsg> msg = std::make_shared<ControllerReferenceMsg>();


### PR DESCRIPTION
There are use cases where you want to ensure the reference topic reaches the trajectory generator. For periodic commands like velocity, this is not an issue but there may be cases where you want a position command to be ensured it is executed. The default reference topic in the trajectory generator is best-effort and although highly unlikely, there is always a possibility of an update being dropped. Here we add a reliable reference topic to ensure delivery for certain use cases.