### PR TITLE
Use values, if present in reset dofs service, instead of fb to reset

### DIFF
--- a/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
+++ b/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller.hpp
@@ -216,7 +216,14 @@ protected:
 
   using ControllerResetDofsSrvType = control_msgs::srv::ResetDofs;
 
-  realtime_tools::RealtimeBuffer<std::vector<bool>> reset_dofs_flags_;
+  struct ResetDofsData
+  {
+    bool reset;
+    double position;
+    double velocity;
+    double acceleration;
+  };
+  realtime_tools::RealtimeBuffer<std::vector<ResetDofsData>> reset_dofs_flags_;
   rclcpp::Service<ControllerResetDofsSrvType>::SharedPtr reset_dofs_service_;
 
   using ControllerStateMsg = control_msgs::msg::JointTrajectoryControllerState;


### PR DESCRIPTION
The reset dofs service call now has optional values of position, velocity and acceleration. See https://github.com/SchillingRobotics/control_msgs-sr/pull/1
If these values are present, when resetting axis using the reset dofs service, use these values instead of the current odometry feedback to reset the internal state in open-loop mode.

The rationale for this is that the z-axis control has two different reference points in the subsea domain. One is the normal depth which is the distance from the surface and is the default understanding of z and is the normal z feedback in the odometry feedback message. The other is altitude which is the distance above the seafloor. This change allows us to set the internal state for z from altitude instead of the normal z depth.

Addresses ROVROS-1793